### PR TITLE
Fix typo

### DIFF
--- a/public/app/core/components/ForgottenPassword/ChangePassword.tsx
+++ b/public/app/core/components/ForgottenPassword/ChangePassword.tsx
@@ -47,7 +47,7 @@ export const ChangePassword: FC<Props> = ({ onSubmit, onSkip }) => {
 
             {onSkip && (
               <Tooltip
-                content="If you skip you will be prompted to change password next time you login."
+                content="If you skip you will be prompted to change password next time you log in."
                 placement="bottom"
               >
                 <LinkButton variant="link" onClick={onSkip} aria-label={selectors.pages.Login.skip}>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix spelling typo. See "log in" (verb) vs "login" (noun) : https://english.stackexchange.com/a/5304/354852
